### PR TITLE
Add JSON upload to registration page

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -1,28 +1,3 @@
-# Face Registration & UI/UX Improvements Checklist
+# Development Checklist
 
-- [x] Progress indicator showing number of captures completed during registration
-- [x] Clear on-screen tips guiding the user to face the camera and move slowly
-- [x] Display remaining captures and allow retakes before final submission
-- [x] Alert when more than one face is detected to avoid incorrect enrollment
-- [x] Responsive layout updates for small screen/mobile devices
-- [x] Detect device orientation and prompt users to rotate to portrait
-- [x] Use full-screen overlay to focus camera feed on mobile
-- [x] Large touch-friendly buttons for capture and controls
-- [x] Option to cancel or restart registration from the page
-- [x] Preview captured frames so users can confirm quality
-- [x] Improve error messages with specific instructions when registration fails
-- [x] Consider storing registrations locally with IndexedDB for offline flow
-
-
-## Descriptor Accuracy & Reliability
-
-- [x] Calibrate `registrationSimilarityThreshold`, `consistencyThreshold`, and `vle_distance_rate` using real-world samples.
-- [x] Average accepted descriptors to create a mean descriptor per user.
-- [x] Reject captures with low quality (blur, extreme angles, poor lighting).
-- [x] Log the distance between each attempt to refine thresholds.
-- [x] Verify new captures are unique across all users to prevent duplicates.
-
-## Planned Changes
-
-- [x] Move registration progress storage from `localStorage` to IndexedDB.
-- [x] Stop persisting completed registrations in IndexedDB and download them only.
+- [ ] Add file input to registration page for loading existing face JSONs.

--- a/face_register.html
+++ b/face_register.html
@@ -308,7 +308,8 @@
 		<a href="#" onclick="urlReplace('index.html')">Go to Index</a><br>
 		<!-- Add user ID and name inputs -->
 		<label>User ID: <input type="text" id="userIdInput" placeholder="Enter user ID"></label>
-		<label>User Name: <input type="text" id="userNameInput" placeholder="Enter user name"></label><br>
+                <label>User Name: <input type="text" id="userNameInput" placeholder="Enter user name"></label><br>
+                <input type="file" id="jsonFileInput" accept=".json" onchange="handleJsonFileInput(event)" multiple><br>
                 <div id="registrationMessage"></div>
                 <p id="tips" style="margin-top:10px;color:#555;font-size:0.9rem;">Keep your face centered and move slowly.</p>
                <div id="progressContainer" class="controls">

--- a/plan.md
+++ b/plan.md
@@ -21,3 +21,7 @@
 - [ ] Implement server-side API to upload stored registrations
 - [ ] Provide user feedback when offline or syncing fails
 - [ ] Option to clear local registrations after successful sync
+
+## Upcoming
+
+- [ ] Allow uploading existing face JSON files on the registration page so duplicates are checked during enrollment.


### PR DESCRIPTION
## Summary
- enable existing face descriptors to be loaded during registration
- clear checklist and add fresh entry
- add upcoming task to the plan

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684175abe36c8331b765d7a377dc741b