### PR TITLE
Update progress container interaction

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -421,8 +421,7 @@
 
                         document.addEventListener('DOMContentLoaded', () => {
                                 const container = document.getElementById('progressContainer');
-                                const bar = document.getElementById('progressBar');
-                                bar.addEventListener('click', (e) => {
+                                container.addEventListener('click', (e) => {
                                         container.classList.toggle('expanded');
                                         e.stopPropagation();
                                 });


### PR DESCRIPTION
## Summary
- toggle progress control visibility when user taps the entire progress container instead of only the progress bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68423ce7b4d88331b0733b7ab5d0c2e9