### PR TITLE
Hide message element when text cleared

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -335,6 +335,9 @@
                                border-radius:4px;
                                display:inline-block;
                        }
+                       #registrationMessage{
+                               display:none;
+                       }
                        </style>
 		
 		<!-- Load face-api core library first -->

--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -149,12 +149,16 @@ function showMessage(type, message) {
     if (msgEl) {
         msgEl.innerText = message;
         msgEl.style.color = type === 'error' ? 'red' : 'green';
+        msgEl.style.display = message ? 'inline-block' : 'none';
         if (msgEl._hideTimer) {
             clearTimeout(msgEl._hideTimer);
         }
-        msgEl._hideTimer = setTimeout(() => {
-            msgEl.innerText = '';
-        }, 5000);
+        if (message) {
+            msgEl._hideTimer = setTimeout(() => {
+                msgEl.innerText = '';
+                msgEl.style.display = 'none';
+            }, 5000);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- hide registrationMessage by default
- update showMessage to toggle visibility based on text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842477f8f3083319f1172280e2f9594