### PR TITLE
Clear saved registration progress on reload

### DIFF
--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -1039,6 +1039,7 @@ async function startInMainThread() {
 
 // Initialize either service worker or fallback on main thread
 document.addEventListener("DOMContentLoaded", async function(event) {
+    clearProgress();
     loadProgress();
     adjustDetectionForDevice();
     console.log("DOMContentLoaded - checking Service Worker support");


### PR DESCRIPTION
## Summary
- remove previously saved face registration data each time the page loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842780f897483318cff040d2920aa61