### PR TITLE
Update registration UI toggling

### DIFF
--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -212,6 +212,8 @@ function restartRegistration() {
     faceapi_action = 'register';
     updateProgress();
     clearProgress();
+    const container = document.querySelector('.face-detection-container');
+    if (container) container.style.display = 'flex';
     camera_start();
 }
 
@@ -226,6 +228,8 @@ function cancelRegistration() {
     if (preview) preview.innerHTML = '';
     updateProgress();
     clearProgress();
+    const container = document.querySelector('.face-detection-container');
+    if (container) container.style.display = 'none';
 }
 
 function isConsistentWithCurrentUser(descriptor) {


### PR DESCRIPTION
## Summary
- hide the face detection container when cancelling registration
- show the container again when restarting registration

## Testing
- `node simple_test.js` *(shows container style becomes `flex` on restart and `none` on cancel)*

------
https://chatgpt.com/codex/tasks/task_e_6842d24033e08331bd535b0d43635cc9