### PR TITLE
Fix overlay persistence on retry

### DIFF
--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -212,6 +212,14 @@ function restartRegistration() {
     faceapi_action = 'register';
     updateProgress();
     clearProgress();
+    [canvasId, canvasId2, canvasId3, canvasOutputId].forEach(id => {
+        const c = document.getElementById(id);
+        if (c) {
+            const ctx = c.getContext('2d');
+            ctx.clearRect(0, 0, c.width, c.height);
+            c.style.display = 'none';
+        }
+    });
     const container = document.querySelector('.face-detection-container');
     if (container) container.style.display = 'flex';
     camera_start();


### PR DESCRIPTION
## Summary
- clear detection canvases when restarting registration to remove old data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842d7b3a7a483319506a53f536a97a1