### PR TITLE
Handle empty detections for face boxes

### DIFF
--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -642,6 +642,17 @@ function clear_landmarks() {
     canvas.style.display = 'none';
 }
 
+/**
+ * Clears the face bounding box overlay canvas and hides it.
+ */
+function clear_boxes() {
+    const canvas = document.getElementById(canvasId3);
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    canvas.style.display = 'none';
+}
+
 var registeredDescriptors = [];
 var maxCaptures = 20;
 var registrationCompleted = false;
@@ -1192,6 +1203,7 @@ function drawAllBoxesAndLabels(detectionsArray) {
 function drawAllFaces(detectionsArray) {
     if (!Array.isArray(detectionsArray) || detectionsArray.length === 0) {
         clear_landmarks();
+        clear_boxes();
         return;
     }
     drawAllLandmarks(detectionsArray);


### PR DESCRIPTION
## Summary
- add `clear_boxes()` utility similar to `clear_landmarks()`
- clear bounding box overlay when no detections

## Testing
- `node --check js/faceapi_warmup.js`

------
https://chatgpt.com/codex/tasks/task_e_684780173bb883319fc895ef14aaa5b1