### PR TITLE
Add pause/resume on progress container toggle

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -496,19 +496,29 @@
 			window.addEventListener('orientationchange', checkOrientation);
 			window.addEventListener('resize', checkOrientation);
 			
-			document.addEventListener('DOMContentLoaded', () => {
-				const container = document.getElementById('progressContainer');
-				container.addEventListener('click', (e) => {
-					container.classList.toggle('expanded');
-					e.stopPropagation();
-				});
-				document.addEventListener('click', (e) => {
-					if(!container.contains(e.target)){
-						container.classList.remove('expanded');
-					}
-				});
-			});
-		</script>
+                        document.addEventListener('DOMContentLoaded', () => {
+                                const container = document.getElementById('progressContainer');
+                                const video = document.getElementById('video');
+                                container.addEventListener('click', (e) => {
+                                        container.classList.toggle('expanded');
+                                        if(container.classList.contains('expanded')){
+                                                video.pause();
+                                        } else {
+                                                video.play();
+                                        }
+                                        e.stopPropagation();
+                                });
+                                document.addEventListener('click', (e) => {
+                                        if(!container.contains(e.target)){
+                                                const wasExpanded = container.classList.contains('expanded');
+                                                container.classList.remove('expanded');
+                                                if(wasExpanded){
+                                                        video.play();
+                                                }
+                                        }
+                                });
+                        });
+                </script>
 		
 		<div class="face-detection-container"  style="display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;">
 			<div class="video-wrapper">


### PR DESCRIPTION
## Summary
- when the progress panel is expanded, pause the camera video
- resume playback once the panel collapses

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68493221af7083318c75699ee5915c53