### PR TITLE
Update capture preview layout

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -135,7 +135,7 @@
                         /* Preview thumbnails container */
                         #capturePreview{
                                 display:flex;
-                                flex-wrap:wrap;
+                                flex-wrap:nowrap;
                                 gap:4px;
                                 margin-bottom:10px;
                                 max-width:100%;
@@ -310,10 +310,14 @@
 				overflow:hidden;
 				transition:max-height 0.3s ease, opacity 0.3s ease;
 			}
-			#progressContainer.expanded #progressButtons{
-				max-height:200px;
-				opacity:1;
-			}
+                        #progressContainer.expanded #progressButtons{
+                                max-height:200px;
+                                opacity:1;
+                        }
+                        #progressContainer.expanded #capturePreview{
+                                flex-wrap:wrap;
+                                overflow-y:auto;
+                        }
 			.ctrl-btn{
 				padding:14px 18px;
 				font-size:1.1rem;


### PR DESCRIPTION
## Summary
- keep capture thumbnails in a single row
- allow wrapping thumbnails when progress container expands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68493b0a656c8331b1c92c2b5f7bb286