### PR TITLE
Fix capture preview scroll

### DIFF
--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -197,7 +197,10 @@ function addCapturePreview(dataUrl) {
     ta.value = dataUrl;
     preview.appendChild(ta);
 
-    requestAnimationFrame(() => img.classList.add('show'));
+    requestAnimationFrame(() => {
+        img.classList.add('show');
+        preview.scrollLeft = preview.scrollWidth;
+    });
 }
 
 function retakeLastCapture() {


### PR DESCRIPTION
## Summary
- keep latest capture visible by scrolling preview container

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68493cae8f508331b3f7619dbff9f0f1