### PR TITLE
Improve capture-preview behavior

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -526,6 +526,7 @@
                                 const container = document.getElementById('progressContainer');
                                 const video = document.getElementById('video');
                                 container.addEventListener('click', (e) => {
+                                        if(e.target.classList.contains('capture-thumb')) return;
                                         container.classList.toggle('expanded');
                                         if(container.classList.contains('expanded')){
                                                 video.pause();

--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -1157,6 +1157,13 @@ document.addEventListener("DOMContentLoaded", async function(event) {
     if (capturePreviewEl) {
         capturePreviewEl.addEventListener('click', e => {
             if (e.target.classList.contains('capture-thumb')) {
+                e.stopPropagation();
+                const progressContainer = document.getElementById('progressContainer');
+                const video = document.getElementById('video');
+                if (progressContainer && !progressContainer.classList.contains('expanded')) {
+                    progressContainer.classList.add('expanded');
+                    if (video) video.pause();
+                }
                 const modal = document.getElementById('imageModal');
                 if (modal) {
                     modal.querySelector('img').src = e.target.src;


### PR DESCRIPTION
## Summary
- stop propagation when clicking a preview thumbnail
- auto-expand progress container and pause video on thumbnail click
- ignore thumbnail clicks for container toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68494568e9e883319510ae5c73a0bd6f