### PR TITLE
Enable sliding modal viewer for captured faces

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -406,7 +406,8 @@
                                 max-height:90%;
                         }
                         .modal .prev,
-                        .modal .next{
+                        .modal .next,
+                        .modal .close{
                                 position:absolute;
                                 top:50%;
                                 transform:translateY(-50%);
@@ -418,6 +419,11 @@
                         }
                         .modal .prev{ left:10px; }
                         .modal .next{ right:10px; }
+                        .modal .close{
+                                top:10px;
+                                right:10px;
+                                transform:none;
+                        }
                 </style>
 		
 		<!-- Load face-api core library first -->


### PR DESCRIPTION
## Summary
- style the modal close button for the captured face preview
- adjust CSS grouping to include navigation buttons and close icon

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a3253153c8331bb32d21e5892bc6d