### PR TITLE
Fix slider width for modal images

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -399,11 +399,13 @@
                                 display:flex;
                                 overflow:hidden;
                                 transition:transform 0.3s ease;
+                                width:100%;
                         }
                         .slide-wrapper img{
                                 flex:0 0 100%;
-                                max-width:90%;
+                                width:100%;
                                 max-height:90%;
+                                object-fit:contain;
                         }
                         .modal .prev,
                         .modal .next,


### PR DESCRIPTION
## Summary
- ensure `.slide-wrapper` fills the modal width
- make `.slide-wrapper img` stretch to the wrapper using `width:100%`
- keep images contained with `object-fit:contain`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a37a73a8c8331ae267b1f2db5c5f3