### PR TITLE
Link timer to video pause

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -549,8 +549,10 @@
                                         container.classList.toggle('expanded');
                                         if(container.classList.contains('expanded')){
                                                 video.pause();
+                                                if(typeof pauseRegistrationTimer === 'function') pauseRegistrationTimer();
                                         } else {
                                                 video.play();
+                                                if(typeof resumeRegistrationTimer === 'function') resumeRegistrationTimer();
                                         }
                                         e.stopPropagation();
                                 });
@@ -560,6 +562,7 @@
                                                 container.classList.remove('expanded');
                                                 if(wasExpanded){
                                                         video.play();
+                                                        if(typeof resumeRegistrationTimer === 'function') resumeRegistrationTimer();
                                                 }
                                         }
                                 });

--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -740,6 +740,25 @@ function stopRegistrationTimer(triggerTimeout = false) {
     }
 }
 
+function pauseRegistrationTimer() {
+    if (registrationTimer) {
+        clearInterval(registrationTimer);
+        registrationTimer = null;
+    }
+}
+
+function resumeRegistrationTimer() {
+    if (!registrationTimer && timeLeft > 0) {
+        registrationTimer = setInterval(() => {
+            timeLeft--;
+            updateTimerText();
+            if (timeLeft <= 0) {
+                stopRegistrationTimer(true);
+            }
+        }, 1000);
+    }
+}
+
 function faceapi_register(descriptor) {
     if (!descriptor || registrationCompleted) {
         return;
@@ -1198,6 +1217,7 @@ document.addEventListener("DOMContentLoaded", async function(event) {
                 if (progressContainer && !progressContainer.classList.contains('expanded')) {
                     progressContainer.classList.add('expanded');
                     if (video) video.pause();
+                    if (typeof pauseRegistrationTimer === 'function') pauseRegistrationTimer();
                 }
 
                 showModalImage(parseInt(e.target.dataset.index));


### PR DESCRIPTION
## Summary
- pause/resume registration timer with video
- stop timer when progress panel expands
- resume timer when progress panel collapses

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a527f1b5c8331b2b1c490a82330f6