### PR TITLE
Prevent progress container collapsing when modal active

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -545,32 +545,34 @@
 			window.addEventListener('orientationchange', checkOrientation);
 			window.addEventListener('resize', checkOrientation);
 			
-                        document.addEventListener('DOMContentLoaded', () => {
-                                const container = document.getElementById('progressContainer');
-                                const video = document.getElementById('video');
-                                container.addEventListener('click', (e) => {
-                                        if(e.target.classList.contains('capture-thumb')) return;
-                                        container.classList.toggle('expanded');
-                                        if(container.classList.contains('expanded')){
-                                                video.pause();
-                                                if(typeof pauseRegistrationTimer === 'function') pauseRegistrationTimer();
-                                        } else {
-                                                video.play();
-                                                if(typeof resumeRegistrationTimer === 'function') resumeRegistrationTimer();
-                                        }
-                                        e.stopPropagation();
-                                });
-                                document.addEventListener('click', (e) => {
-                                        if(!container.contains(e.target)){
-                                                const wasExpanded = container.classList.contains('expanded');
-                                                container.classList.remove('expanded');
-                                                if(wasExpanded){
+                                document.addEventListener('DOMContentLoaded', () => {
+                                        const container = document.getElementById('progressContainer');
+                                        const video = document.getElementById('video');
+                                        const modal = document.getElementById('imageModal');
+                                        container.addEventListener('click', (e) => {
+                                                if(e.target.classList.contains('capture-thumb')) return;
+                                                container.classList.toggle('expanded');
+                                                if(container.classList.contains('expanded')){
+                                                        video.pause();
+                                                        if(typeof pauseRegistrationTimer === 'function') pauseRegistrationTimer();
+                                                } else {
                                                         video.play();
                                                         if(typeof resumeRegistrationTimer === 'function') resumeRegistrationTimer();
                                                 }
-                                        }
+                                                e.stopPropagation();
+                                        });
+                                        document.addEventListener('click', (e) => {
+                                                if(modal && modal.style.display === 'flex') return;
+                                                if(!container.contains(e.target)){
+                                                        const wasExpanded = container.classList.contains('expanded');
+                                                        container.classList.remove('expanded');
+                                                        if(wasExpanded){
+                                                                video.play();
+                                                                if(typeof resumeRegistrationTimer === 'function') resumeRegistrationTimer();
+                                                        }
+                                                }
+                                        });
                                 });
-                        });
                 </script>
 		
 		<div class="face-detection-container"  style="display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;">

--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -1228,6 +1228,7 @@ document.addEventListener("DOMContentLoaded", async function(event) {
     if (modalEl) {
         const prevBtn = modalEl.querySelector('.prev');
         const nextBtn = modalEl.querySelector('.next');
+        const imgInModal = modalEl.querySelector('img');
         if (prevBtn) prevBtn.addEventListener('click', e => {
             e.stopPropagation();
             if (currentModalIndex > 0) {
@@ -1239,6 +1240,9 @@ document.addEventListener("DOMContentLoaded", async function(event) {
             if (currentModalIndex < capturedFrames.length - 1) {
                 showModalImage(currentModalIndex + 1);
             }
+        });
+        if (imgInModal) imgInModal.addEventListener('click', e => {
+            e.stopPropagation();
         });
         let touchStartX = 0;
         modalEl.addEventListener('touchstart', e => {


### PR DESCRIPTION
## Summary
- ensure clicks on the image modal don't collapse the progress panel
- ignore outside clicks while the image modal is displayed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a5c766a28833191f7d5213c5e5e78