### PR TITLE
Enable large progress container

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -287,18 +287,22 @@
 				justify-content:center;
 				align-items:center;
 			}
-			#progressContainer{
-				position:fixed;
-				bottom:0;
-				left:0;
-				width:100%;
-				z-index:999;
-				background:rgba(255,255,255,0.8);
-				box-shadow:0 -2px 4px rgba(0,0,0,0.1);
-				padding:0.5rem;
-				margin: 0 auto;
-				border-radius: 25px 25px 0px 0px;
-			}
+                        #progressContainer{
+                                position:fixed;
+                                bottom:0;
+                                left:0;
+                                width:100%;
+                                z-index:999;
+                                background:rgba(255,255,255,0.8);
+                                box-shadow:0 -2px 4px rgba(0,0,0,0.1);
+                                padding:0.5rem;
+                                margin: 0 auto;
+                                border-radius: 25px 25px 0px 0px;
+                        }
+                        #progressContainer.expanded{
+                                top:15vh;
+                                overflow-y:auto;
+                        }
 			#progressButtons{
 				width:100%;
 				display:flex;


### PR DESCRIPTION
## Summary
- allow the progress panel to fill most of the screen when expanded

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684a6568ee54833185ead79730a55524