### PR TITLE
Add manual download button after registration

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -507,7 +507,8 @@
 					<button id="retakeBtn" class="ctrl-btn">Retake Last</button>
 				</div>
 				<button id="restartBtn" class="ctrl-btn">Restart</button>
-				<button id="cancelBtn" class="ctrl-btn">Cancel</button>
+                                <button id="downloadBtn" class="ctrl-btn" style="display:none;">Download</button>
+                                <button id="cancelBtn" class="ctrl-btn">Cancel</button>
 			</div>
                 <div id="capturePreview"></div>
                 </div>


### PR DESCRIPTION
## Summary
- add a new **Download** button to the registration controls
- stop auto download when registration completes
- show the download button and expand controls when 20 faces are captured
- keep the Restart button visible at all times
- expose a function to download the JSON when clicked

## Testing
- `node --check js/faceDetectionServiceWorker.js`
- `node --check js/faceapi_warmup.js`


------
https://chatgpt.com/codex/tasks/task_e_684a74e3d19c83318efd2c0ab51b52c6