### PR TITLE
Add verification toast & completion modal

### DIFF
--- a/face_verify.html
+++ b/face_verify.html
@@ -172,23 +172,81 @@
                                         margin-top:0.5rem;
                                 }
                         }
+
+                        #verifyToast{
+                                position:fixed;
+                                bottom:20px;
+                                left:50%;
+                                transform:translateX(-50%);
+                                background:rgba(0,0,0,0.7);
+                                color:#fff;
+                                padding:8px 12px;
+                                border-radius:4px;
+                                opacity:0;
+                                pointer-events:none;
+                                transition:opacity 0.3s ease;
+                                z-index:10005;
+                        }
+                        #verifyToast.show{ opacity:1; }
+
+                        #verifyCompleteOverlay{
+                                position:fixed;
+                                inset:0;
+                                background:rgba(0,0,0,0.85);
+                                color:white;
+                                display:none;
+                                justify-content:center;
+                                align-items:center;
+                                text-align:center;
+                                padding:1rem;
+                                z-index:10003;
+                                font-size:1.2rem;
+                        }
+                        #verifyCompleteOverlay button{
+                                margin:0.5rem;
+                                padding:12px 16px;
+                                font-size:1rem;
+                                border:none;
+                                border-radius:6px;
+                                background:#4CAF50;
+                                color:#fff;
+                        }
                 </style>
 		
 		<!-- Load face-api core library first -->
 		<script src="./js/face-api.min.js"></script>
 		<!-- Then load the warm-up helper that depends on face-api -->
 		<script src="./js/faceapi_warmup.js"></script>
-		<script>
-			function urlReplace(url) {
-				window.location.replace(url);
-			}
-		</script>
-	</head>
-	<body>
-		<div style="display:none;">
-			<h1>Face Detection</h1>
-			<a href="#" onclick="urlReplace('index.html')">Go to Index</a><br>
+                <script>
+                        function urlReplace(url) {
+                                window.location.replace(url);
+                        }
+                        function showVerifyCompleteOverlay(){
+                                const el = document.getElementById('verifyCompleteOverlay');
+                                if(el){
+                                        el.style.display = 'flex';
+                                }
+                        }
+                        function hideVerifyCompleteOverlay(){
+                                const el = document.getElementById('verifyCompleteOverlay');
+                                if(el){
+                                        el.style.display = 'none';
+                                }
+                        }
+                </script>
+        </head>
+        <body>
+                <div style="display:none;">
+                        <h1>Face Detection</h1>
+                        <a href="#" onclick="urlReplace('index.html')">Go to Index</a><br>
                 </div>
+                <div id="verifyCompleteOverlay">
+                        <div>
+                                <p>Face verification completed.</p>
+                                <button onclick="hideVerifyCompleteOverlay()">OK</button>
+                        </div>
+                </div>
+                <div id="verifyToast"></div>
                         <input type="file" id="jsonFileInput" accept=".json" onchange="handleJsonFileInput(event)" multiple>
 
                 <div id="verifyProgressContainer" class="controls">

--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -174,6 +174,19 @@ function showMessage(type, message) {
     }
 }
 
+function showVerifyToast(message) {
+    const toast = document.getElementById('verifyToast');
+    if (!toast) return;
+    toast.innerText = message;
+    toast.classList.add('show');
+    if (toast._hideTimer) {
+        clearTimeout(toast._hideTimer);
+    }
+    toast._hideTimer = setTimeout(() => {
+        toast.classList.remove('show');
+    }, 3000);
+}
+
 
 function updateProgress() {
     const el = document.getElementById('progressText');
@@ -937,11 +950,12 @@ function faceapi_verify(descriptor){
                 verifiedUserIds.add(uid);
                 verifiedCount++;
                 updateVerifyProgress();
+                showVerifyToast(`${userMeta.name} (${userMeta.id}) detected`);
                 if (verifiedCount >= totalVerifyFaces) {
                     camera_stop();
                     verificationCompleted = true;
                     faceapi_action = null;
-                    alert('Verification complete');
+                    if (typeof showVerifyCompleteOverlay === 'function') showVerifyCompleteOverlay();
                 }
             }
             if (multiple_face_detection_yn !== "y") {


### PR DESCRIPTION
## Summary
- show short-lived toast when verifying a user
- notify with overlay when all required faces verified
- style and insert new UI elements for verification page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ba82cc8ec833197269543f6b7486d