### PR TITLE
Add verification panel interactions

### DIFF
--- a/face_verify.html
+++ b/face_verify.html
@@ -129,6 +129,27 @@
                                 flex-wrap:wrap;
                                 overflow-y:auto;
                         }
+                        #verifyCapturePreview{
+                                display:flex;
+                                flex-wrap:nowrap;
+                                gap:4px;
+                                margin-bottom:10px;
+                                max-width:100%;
+                                overflow-x:auto;
+                        }
+                        #verifyProgressContainer textarea[id^="verifyCapturePreview_"]{
+                                display:none;
+                        }
+                        .capture-thumb{
+                                width:64px;
+                                height:64px;
+                                object-fit:cover;
+                                border:1px solid #ccc;
+                                border-radius:4px;
+                                opacity:0;
+                                transition:opacity 0.3s ease;
+                        }
+                        .capture-thumb.show{ opacity:1; }
                         .ctrl-btn{
                                 padding:14px 18px;
                                 font-size:1.1rem;

--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -1268,6 +1268,28 @@ document.addEventListener("DOMContentLoaded", async function(event) {
     const verifyCancel = document.getElementById('verifyCancelBtn');
     if (verifyRestart) verifyRestart.addEventListener('click', restartVerification);
     if (verifyCancel) verifyCancel.addEventListener('click', cancelVerification);
+
+    const verifyContainer = document.getElementById('verifyProgressContainer');
+    if (verifyContainer) {
+        const videoEl = document.getElementById('video');
+        verifyContainer.addEventListener('click', e => {
+            if (e.target.classList.contains('capture-thumb')) return;
+            verifyContainer.classList.toggle('expanded');
+            if (verifyContainer.classList.contains('expanded')) {
+                if (videoEl) videoEl.pause();
+            } else {
+                if (videoEl) videoEl.play();
+            }
+            e.stopPropagation();
+        });
+        document.addEventListener('click', e => {
+            if (!verifyContainer.contains(e.target)) {
+                const wasExpanded = verifyContainer.classList.contains('expanded');
+                verifyContainer.classList.remove('expanded');
+                if (wasExpanded && videoEl) videoEl.play();
+            }
+        });
+    }
     // ----- Preview thumbnail interaction -----
     // Each captured frame is rendered as a small thumbnail inside the progress
     // container.  When the user taps on a thumbnail we want to show a larger


### PR DESCRIPTION
## Summary
- style the verification progress panel same as registration
- expand/collapse verify progress container via JS
- pause video while container expanded
- hook restart/cancel buttons for verification

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bacd8f5748331b9c698bb46b4456b