### PR TITLE
Add progress list for face verification

### DIFF
--- a/face_verify.html
+++ b/face_verify.html
@@ -150,6 +150,23 @@
                                 transition:opacity 0.3s ease;
                         }
                         .capture-thumb.show{ opacity:1; }
+                        #verifyPersonList{
+                                list-style:none;
+                                padding:0;
+                                margin:4px 0;
+                                width:100%;
+                                font-size:0.9rem;
+                        }
+                        #verifyPersonList li{
+                                display:flex;
+                                justify-content:space-between;
+                                padding:2px 4px;
+                                border-bottom:1px solid #ccc;
+                        }
+                        #verifyPersonList li.verified{
+                                background:#d4ffd4;
+                                font-weight:bold;
+                        }
                         .ctrl-btn{
                                 padding:14px 18px;
                                 font-size:1.1rem;
@@ -282,6 +299,7 @@
                                 <button id="verifyCancelBtn" class="ctrl-btn ctrl-btn-danger">Cancel</button>
                                 <button id="verifyDownloadBtn" class="ctrl-btn ctrl-btn-success" style="display:none;">Download</button>
                         </div>
+                        <ul id="verifyPersonList"></ul>
                 <div id="verifyCapturePreview"></div>
                 </div>
 		

--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -295,6 +295,14 @@ function restartVerification() {
     verifiedCount = 0;
     verifiedUserIds = new Set();
     verificationCompleted = false;
+    const list = document.getElementById('verifyPersonList');
+    if (list) {
+        Array.from(list.querySelectorAll('li')).forEach(li => {
+            li.classList.remove('verified');
+            const status = li.querySelector('.status');
+            if (status) status.textContent = 'pending';
+        });
+    }
     updateVerifyProgress();
     faceapi_action = 'verify';
     camera_start();
@@ -306,6 +314,14 @@ function cancelVerification() {
     verificationCompleted = true;
     verifiedCount = 0;
     verifiedUserIds = new Set();
+    const list = document.getElementById('verifyPersonList');
+    if (list) {
+        Array.from(list.querySelectorAll('li')).forEach(li => {
+            li.classList.remove('verified');
+            const status = li.querySelector('.status');
+            if (status) status.textContent = 'pending';
+        });
+    }
     updateVerifyProgress();
 }
 
@@ -512,6 +528,18 @@ async function load_face_descriptor_json(warmupFaceDescriptorJson, merge = false
             registeredDescriptors = descriptors;
             flatRegisteredDescriptors = descriptors;
             flatRegisteredUserMeta = descriptors.map(() => ({ id: null, name: null }));
+        }
+
+        const listEl = document.getElementById('verifyPersonList');
+        if (listEl) {
+            listEl.innerHTML = '';
+            registeredUsers.forEach(u => {
+                const li = document.createElement('li');
+                li.dataset.userId = u.id;
+                const name = u.name || 'Unknown';
+                li.innerHTML = `${name} (${u.id}) – <span class="status">pending</span>`;
+                listEl.appendChild(li);
+            });
         }
 
         totalVerifyFaces = registeredUsers.length;
@@ -949,6 +977,12 @@ function faceapi_verify(descriptor){
             if (uid && !verifiedUserIds.has(uid)) {
                 verifiedUserIds.add(uid);
                 verifiedCount++;
+                const li = document.querySelector(`#verifyPersonList li[data-user-id="${uid}"]`);
+                if (li) {
+                    const status = li.querySelector('.status');
+                    if (status) status.textContent = 'verified';
+                    li.classList.add('verified');
+                }
                 updateVerifyProgress();
                 showVerifyToast(`${userMeta.name} (${userMeta.id}) detected`);
                 if (verifiedCount >= totalVerifyFaces) {


### PR DESCRIPTION
## Summary
- show list of users being verified in the progress panel
- highlight verified users in the list
- reset verification states on restart/cancel

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684bb6702f408331ab26881ab98baa2f