### PR TITLE
Clear overlay after verification

### DIFF
--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -323,6 +323,7 @@ function cancelVerification() {
         });
     }
     updateVerifyProgress();
+    clear_all_canvases();
 }
 
 function downloadRegistrationData() {
@@ -990,6 +991,7 @@ function faceapi_verify(descriptor){
                     verificationCompleted = true;
                     faceapi_action = null;
                     if (typeof showVerifyCompleteOverlay === 'function') showVerifyCompleteOverlay();
+                    clear_all_canvases();
                 }
             }
             if (multiple_face_detection_yn !== "y") {


### PR DESCRIPTION
## Summary
- clear overlay canvases after verification completes or is cancelled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684bc5689fc8833198f0d7afa826ac88