### PR TITLE
Add textarea-based face verification

### DIFF
--- a/face_verify.html
+++ b/face_verify.html
@@ -286,8 +286,9 @@
 				<button onclick="hideVerifyCompleteOverlay()">OK</button>
 			</div>
 		</div>
-		<div id="verifyToast"></div>
-		<input type="file" id="jsonFileInput" accept=".json" onchange="handleJsonFileInput(event)" multiple>
+                <div id="verifyToast"></div>
+                <input type="file" id="jsonFileInput" accept=".json" onchange="handleJsonFileInput(event)" multiple>
+                <textarea class="all_face_id_for_verification" style="display:none;"></textarea>
 		
 		<div id="verifyProgressContainer" class="controls">
 			<span id="verifyProgressText">0/0 verified.</span>


### PR DESCRIPTION
## Summary
- allow uploading verification face JSONs into a hidden textarea
- trigger verification when that textarea contains valid JSON
- store last loaded JSON to avoid duplicate starts

## Testing
- `node --check js/faceapi_warmup.js`

------
https://chatgpt.com/codex/tasks/task_e_684f7c01c3f083319ef75b22d19af9ce