### PR TITLE
Add face verification result output

### DIFF
--- a/face_verify.html
+++ b/face_verify.html
@@ -289,6 +289,7 @@
                 <div id="verifyToast"></div>
                 <input type="file" id="jsonFileInput" accept=".json" onchange="handleJsonFileInput(event)" multiple>
                 <textarea class="all_face_id_for_verification" style="display:none;"></textarea>
+                <textarea class="face_verification_result" style="display:none;"></textarea>
 		
 		<div id="verifyProgressContainer" class="controls">
 			<span id="verifyProgressText">0/0 verified.</span>

--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -63,6 +63,7 @@ var registeredUsers = [];
 var flatRegisteredDescriptors = [];
 var flatRegisteredUserMeta = [];
 var lastLoadedVerificationJson = '';
+var verificationResults = [];
 // Flag to allow multiple face detection ("y" = allow multiple, else single)
 var multiple_face_detection_yn = "y";
 
@@ -304,6 +305,8 @@ function restartVerification() {
             if (status) status.textContent = 'pending';
         });
     }
+    verificationResults = registeredUsers.map(u => ({ id: u.id, name: u.name, verified: false }));
+    updateVerificationResultTextarea();
     updateVerifyProgress();
     faceapi_action = 'verify';
     camera_start();
@@ -323,6 +326,8 @@ function cancelVerification() {
             if (status) status.textContent = 'pending';
         });
     }
+    verificationResults = registeredUsers.map(u => ({ id: u.id, name: u.name, verified: false }));
+    updateVerificationResultTextarea();
     updateVerifyProgress();
     clear_all_canvases();
 }
@@ -357,6 +362,14 @@ function downloadRegistrationData() {
     link.download = 'faceid_with_users.json';
     link.click();
     URL.revokeObjectURL(url);
+}
+
+function updateVerificationResultTextarea() {
+    const ta = document.querySelector('.face_verification_result');
+    if (ta) {
+        ta.value = JSON.stringify(verificationResults, null, 2);
+        ta.dispatchEvent(new Event('input', { bubbles: true }));
+    }
 }
 
 function isConsistentWithCurrentUser(descriptor) {
@@ -561,6 +574,9 @@ async function load_face_descriptor_json(warmupFaceDescriptorJson, merge = false
                 listEl.appendChild(li);
             });
         }
+
+        verificationResults = registeredUsers.map(u => ({ id: u.id, name: u.name, verified: false }));
+        updateVerificationResultTextarea();
 
         totalVerifyFaces = registeredUsers.length;
         verifiedCount = 0;
@@ -1004,6 +1020,8 @@ function faceapi_verify(descriptor){
                     if (status) status.textContent = 'verified';
                     li.classList.add('verified');
                 }
+                verificationResults = verificationResults.map(r => r.id === uid ? { ...r, verified: true } : r);
+                updateVerificationResultTextarea();
                 updateVerifyProgress();
                 showVerifyToast(`${userMeta.name} (${userMeta.id}) detected`);
                 if (verifiedCount >= totalVerifyFaces) {


### PR DESCRIPTION
## Summary
- add hidden `face_verification_result` textarea to verification page
- capture verification results in `faceapi_warmup.js`
- update results textarea whenever verification state changes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fb647adb083319e77ec8dd644f220