### PR TITLE
Preserve verification progress on cancel

### DIFF
--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -315,20 +315,9 @@ function restartVerification() {
 function cancelVerification() {
     camera_stop();
     faceapi_action = null;
-    verificationCompleted = true;
-    verifiedCount = 0;
-    verifiedUserIds = new Set();
-    const list = document.getElementById('verifyPersonList');
-    if (list) {
-        Array.from(list.querySelectorAll('li')).forEach(li => {
-            li.classList.remove('verified');
-            const status = li.querySelector('.status');
-            if (status) status.textContent = 'pending';
-        });
-    }
-    verificationResults = registeredUsers.map(u => ({ id: u.id, name: u.name, verified: false }));
-    updateVerificationResultTextarea();
-    updateVerifyProgress();
+    // Preserve current verification progress and results.
+    // Only clear the canvas overlays and stop the camera so the
+    // user can restart verification later if desired.
     clear_all_canvases();
 }
 


### PR DESCRIPTION
## Summary
- modify `cancelVerification` so the cancel button now only stops the camera
- keep all verification results intact until restart is clicked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fb92a317483319c131ac4d824f36c