### PR TITLE
Fix face verification restart

### DIFF
--- a/js/faceapi_warmup.js
+++ b/js/faceapi_warmup.js
@@ -272,7 +272,11 @@ function restartRegistration() {
     clear_all_canvases();
     const container = document.querySelector('.face-detection-container');
     if (container) container.style.display = 'flex';
-    camera_start();
+    camera_start().then(() => {
+        if (!videoDetectionStep) {
+            video_face_detection();
+        }
+    });
 }
 
 function cancelRegistration() {
@@ -309,7 +313,11 @@ function restartVerification() {
     updateVerificationResultTextarea();
     updateVerifyProgress();
     faceapi_action = 'verify';
-    camera_start();
+    camera_start().then(() => {
+        if (!videoDetectionStep) {
+            video_face_detection();
+        }
+    });
 }
 
 function cancelVerification() {
@@ -452,6 +460,8 @@ async function camera_start() {
         try {
                 var stream = await navigator.mediaDevices.getUserMedia({ video: true });
                 video.srcObject = stream;
+                // Start playback explicitly in case autoplay is blocked
+                try { await video.play(); } catch (err) {}
                 const overlay = document.getElementById('permissionOverlay');
                 if (overlay) overlay.style.display = 'none';
         } catch (error) {


### PR DESCRIPTION
## Summary
- ensure video playback restarts via `video.play()` when camera restarts
- reinitialize face detection loop when restarting registration or verification

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684fbb32d8ac8331b3d3c0085f0b57b3