### PR TITLE
Refine orientation overlay check for mobile only

### DIFF
--- a/face_register.html
+++ b/face_register.html
@@ -538,14 +538,15 @@
 				}
 			});
 			
-			function checkOrientation(){
-				const overlay = document.getElementById('orientationOverlay');
-				if(window.innerHeight >= window.innerWidth){
-					overlay.style.display = 'none';
-				}else{
-					overlay.style.display = 'flex';
-				}
-			}
+                        function checkOrientation(){
+                                const overlay = document.getElementById('orientationOverlay');
+                                const isMobile = window.matchMedia('(max-width: 768px)').matches;
+                                if(isMobile && window.innerWidth > window.innerHeight){
+                                        overlay.style.display = 'flex';
+                                }else{
+                                        overlay.style.display = 'none';
+                                }
+                        }
 			
 			window.addEventListener('orientationchange', checkOrientation);
 			window.addEventListener('resize', checkOrientation);

--- a/plan.md
+++ b/plan.md
@@ -2,7 +2,7 @@
 
 - [x] Display a full screen loading overlay while face-api models warm up.
 - [x] Hide the loader once warm up completes using the `warmup_completed` callback.
-- [x] Keep the orientation overlay to prompt portrait mode on mobile.
+- [x] Orientation overlay only displays on mobile devices when held landscape.
 - [x] Provide touch-friendly controls with large buttons.
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- show rotation overlay only when phones are used in landscape orientation
- document new behavior in plan

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857f2d3cd708331a02e801c90978a97